### PR TITLE
Feature: Status Badge - Icon for Widget Generator

### DIFF
--- a/ChainGenerator/Components/Widgets/WidgetGenerator.razor
+++ b/ChainGenerator/Components/Widgets/WidgetGenerator.razor
@@ -1,6 +1,9 @@
 ﻿@using System.Text
 @inject IServiceProvider ServiceProvider
 
+<!-- The badge icon which indicates an ongoing refresh -->
+@if (refreshInProgress)
+    {<MudBadge Origin="Origin.TopLeft" Color="Color.Warning" Overlap="true" Bordered="false" Icon="@badgeIcon" ></MudBadge>}
 <!-- The main card that contains the widget generator -->
 <MudCard Outlined="true">
     <!-- The card header contains the title and action buttons -->
@@ -97,6 +100,8 @@
     private bool refreshInProgress { get; set; } = false;  // Flag for whether a refresh is in progress
     private bool isEditingTitle { get; set; } = false;  // Flag for whether the title is being edited
     private MudTextField<string>? titleRef { get; set; }  // Reference to the title text field
+
+    private string badgeIcon { get; set; } = Icons.Material.Filled.HourglassBottom; // Symbol used by the generation badge
 
     // Methods for handling events and refreshing the generator
     private async Task OnRefreshAsync()

--- a/ChainGenerator/Components/Widgets/WidgetGenerator.razor
+++ b/ChainGenerator/Components/Widgets/WidgetGenerator.razor
@@ -3,7 +3,10 @@
 
 <!-- The badge icon which indicates an ongoing refresh -->
 @if (refreshInProgress)
-    {<MudBadge Origin="Origin.TopLeft" Color="Color.Warning" Overlap="true" Bordered="false" Icon="@badgeIcon" ></MudBadge>}
+{<MudBadge Origin="Origin.TopLeft" Color="Color.Warning" Overlap="true" Bordered="false" Icon="@badgeIcon" ></MudBadge>}
+else //Uses a transparent badge to keep the card formatting consistent 
+{<MudBadge Origin="Origin.TopLeft" Color="Color.Transparent" Overlap="true" Bordered="false" ></MudBadge>}
+
 <!-- The main card that contains the widget generator -->
 <MudCard Outlined="true">
     <!-- The card header contains the title and action buttons -->

--- a/ChainGenerator/Components/Widgets/WidgetGenerator.razor
+++ b/ChainGenerator/Components/Widgets/WidgetGenerator.razor
@@ -3,9 +3,22 @@
 
 <!-- The badge icon which indicates an ongoing refresh -->
 @if (refreshInProgress)
-{<MudBadge Origin="Origin.TopLeft" Color="Color.Warning" Overlap="true" Bordered="false" Icon="@badgeIcon" ></MudBadge>}
+{
+    <MudBadge Origin="Origin.TopLeft"
+              Color="Color.Warning"
+              Overlap="true"
+              Bordered="false"
+              Icon="@badgeIcon">
+    </MudBadge>
+}
 else //Uses a transparent badge to keep the card formatting consistent 
-{<MudBadge Origin="Origin.TopLeft" Color="Color.Transparent" Overlap="true" Bordered="false" ></MudBadge>}
+{
+    <MudBadge Origin="Origin.TopLeft"
+              Color="Color.Transparent"
+              Overlap="true"
+              Bordered="false">
+    </MudBadge>
+}
 
 <!-- The main card that contains the widget generator -->
 <MudCard Outlined="true">

--- a/ChainGenerator/Components/Widgets/WidgetGenerator.razor
+++ b/ChainGenerator/Components/Widgets/WidgetGenerator.razor
@@ -2,23 +2,13 @@
 @inject IServiceProvider ServiceProvider
 
 <!-- The badge icon which indicates an ongoing refresh -->
-@if (refreshInProgress)
-{
-    <MudBadge Origin="Origin.TopLeft"
-              Color="Color.Warning"
-              Overlap="true"
-              Bordered="false"
-              Icon="@badgeIcon">
-    </MudBadge>
-}
-else //Uses a transparent badge to keep the card formatting consistent 
-{
-    <MudBadge Origin="Origin.TopLeft"
-              Color="Color.Transparent"
-              Overlap="true"
-              Bordered="false">
-    </MudBadge>
-}
+<MudBadge Origin="Origin.TopLeft"
+          Color="Color.Warning"
+          Visible="refreshInProgress"
+          Overlap="true"
+          Bordered="false"
+          Icon="@badgeIcon">
+</MudBadge>
 
 <!-- The main card that contains the widget generator -->
 <MudCard Outlined="true">


### PR DESCRIPTION
Added a yellow hourglass icon badge to the main card which indicates that a response is being generated. When a response is not being generated, a transparent badge takes its place to keep page spacing consistent.
<img width="950" alt="Screenshot 2024-02-07 201013" src="https://github.com/Unskilledcrab/chain-generator/assets/109312462/9b13c2d2-4fc1-4d55-a59d-2550988ba26b">
